### PR TITLE
Fix DELETE action when passing an e-mail as parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ruby:2.3.3
 
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+RUN printf "deb http://archive.debian.org/debian/ jessie main\\n \
+            deb-src http://archive.debian.org/debian/ jessie main\\n \
+            deb http://security.debian.org jessie/updates main\\n \
+            deb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update && \
     apt-get install -y net-tools
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.3.3
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y net-tools
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   scope '/feature' do
     delete '/:id', to: 'feature#destroy', as: 'destroy_feature'
-    delete '/:id/user/:user', to: 'feature#delete_user', as: 'delete_user'
+    delete '/:id/user/:user', :constraints => { user: /.+/ }, to: 'feature#delete_user', as: 'delete_user'
     get '/new', to: 'feature#new', as: 'new_feature'
     get '/:id', to: 'feature#show', as: 'feature'
     get '/:id/user/:user', to: 'feature#search_user', as: 'search_user'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3'
 services:
   web:
+    volumes:
+      - .:/app
     build: .
     ports:
       - "3000:3000"


### PR DESCRIPTION
This problem occurs when the parameter passed contains a dot characters which rails does not match the route delete.

There are others commits which fixes a problem to build the container (there are a new version of Debian and because of that, this leads to apt-update to fail).