### PR TITLE
Refact: Update sprockets to 3.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 
+gem "sprockets", ">= 3.7.2"
+
 gem 'jquery-rails'
 gem 'redis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     crass (1.0.4)
     debug_inspector (0.0.3)
     erubis (2.7.0)
@@ -75,7 +75,7 @@ GEM
     minitest (5.11.3)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -120,7 +120,7 @@ GEM
       tilt (>= 1.1, < 3)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -152,6 +152,7 @@ DEPENDENCIES
   redis
   sass-rails (~> 5.0)
   spring
+  sprockets (>= 3.7.2)
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 


### PR DESCRIPTION
Updating sprockets to 3.7.2 due to security vulnerabilities. I tried to update others gem as well but this task requires to upgrade rails.