### PR TITLE
deprecating nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nokogiri (1.10.5)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.4.0)
     rack (1.6.12)
     rack-test (0.6.3)


### PR DESCRIPTION
Tive que fazer o downgrade da biblioteca nokogiri.

Parece que está funcional, mas precisa ser testado.